### PR TITLE
Add inner loop aggregation options

### DIFF
--- a/ciclo/callbacks.py
+++ b/ciclo/callbacks.py
@@ -4,7 +4,18 @@ import os
 from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import Enum, auto
-from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Tuple, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
 from pkbar import Kbar
 from tqdm import tqdm
@@ -24,7 +35,9 @@ from ciclo.utils import get_batch_size, is_scalar
 
 
 AggregationFn = Callable[[List[Any]], Any]
-InnerLoopAggregation = Union[Literal["last", "mean", "sum", "min", "max", "first"], AggregationFn]
+InnerLoopAggregation = Union[
+    Literal["last", "mean", "sum", "min", "max", "first"], AggregationFn
+]
 
 
 def unavailable_dependency(msg: str) -> Any:
@@ -43,7 +56,9 @@ class OptimizationMode(str, Enum):
     max = auto()
 
 
-def _transpose_history(log_history: History) -> Mapping[Collection, Mapping[Entry, List[Any]]]:
+def _transpose_history(
+        log_history: History
+) -> Mapping[Collection, Mapping[Entry, List[Any]]]:
     """Convert a list of (nested) log dictionaries into a (nested) dictionary of lists."""
     result = {}
     for log_dict in log_history:
@@ -121,7 +136,9 @@ class inner_loop(LoopCallbackBase[S]):
     def __get_aggregation_fn(self, collection: Collection) -> AggregationFn:
         if isinstance(self.aggregation, Mapping):
             aggregation = self.aggregation.get(collection, "last")
-            error_message = f"The aggregation ({aggregation}) for collection {collection} must be a str or Callable."
+            error_message = (
+                f"The aggregation ({aggregation}) for collection {collection} must be a str or Callable."
+            )
         else:
             aggregation = self.aggregation
             error_message = f"The aggregation ({aggregation}) must be a str or Callable."

--- a/ciclo/callbacks.py
+++ b/ciclo/callbacks.py
@@ -33,7 +33,6 @@ from ciclo.timetracking import Elapsed, Period
 from ciclo.types import Batch, S
 from ciclo.utils import get_batch_size, is_scalar
 
-
 AggregationFn = Callable[[List[Any]], Any]
 InnerLoopAggregation = Union[
     Literal["last", "mean", "sum", "min", "max", "first"], AggregationFn
@@ -57,7 +56,7 @@ class OptimizationMode(str, Enum):
 
 
 def _transpose_history(
-        log_history: History
+    log_history: History,
 ) -> Mapping[Collection, Mapping[Entry, List[Any]]]:
     """Convert a list of (nested) log dictionaries into a (nested) dictionary of lists."""
     result = {}
@@ -136,12 +135,12 @@ class inner_loop(LoopCallbackBase[S]):
     def __get_aggregation_fn(self, collection: Collection) -> AggregationFn:
         if isinstance(self.aggregation, Mapping):
             aggregation = self.aggregation.get(collection, "last")
-            error_message = (
-                f"The aggregation ({aggregation}) for collection {collection} must be a str or Callable."
-            )
+            error_message = f"The aggregation ({aggregation}) for collection {collection} must be a str or Callable."
         else:
             aggregation = self.aggregation
-            error_message = f"The aggregation ({aggregation}) must be a str or Callable."
+            error_message = (
+                f"The aggregation ({aggregation}) must be a str or Callable."
+            )
 
         if not (isinstance(aggregation, str) or isinstance(aggregation, Callable)):
             raise ValueError(error_message)

--- a/ciclo/callbacks.py
+++ b/ciclo/callbacks.py
@@ -121,7 +121,7 @@ class inner_loop(LoopCallbackBase[S]):
         if isinstance(self.aggregation, str):
             aggregation = self.aggregation
         else:
-            aggregation = self.aggregation[collection]
+            aggregation = self.aggregation.get(collection, "last")
 
         if aggregation == "last":
             return lambda x: x[-1]

--- a/ciclo/loops/common.py
+++ b/ciclo/loops/common.py
@@ -73,6 +73,7 @@ def train_loop(
     catch_keyboard_interrupt: bool = True,
     metadata: Optional[Any] = None,
     batch_size_fn: Optional[Callable[[List[Tuple[int, ...]]], int]] = None,
+    inner_loop_kwargs: Optional[Dict[str, Any]] = None,
 ) -> LoopOutput[S]:
     if tasks is None:
         tasks = {}
@@ -82,6 +83,9 @@ def train_loop(
 
     if isinstance(test_duration, int):
         test_duration = Period.create(steps=test_duration)
+
+    if inner_loop_kwargs is None:
+        inner_loop_kwargs = {}
 
     additionl_tasks: Dict[ScheduleLike, CallbackOrList] = {}
     named_tasks: Dict[str, CallbackOrList] = {}
@@ -145,6 +149,7 @@ def train_loop(
                         stop=test_duration,
                         batch_size_fn=batch_size_fn,
                     ),
+                    **inner_loop_kwargs,
                 )
             )
         test_tasks += named_tasks.pop(ON_EPOCH_END, [])

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -98,7 +98,7 @@ class TestCallbacks:
         inner_loop = ciclo.callbacks.inner_loop(
             "test",
             dummy_inner_loop_fn,
-            aggregation={"stateful_metrics": "first", "metrics": "last"},
+            aggregation={"stateful_metrics": "first"},
         )
 
         log_history, _ = inner_loop(None)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -55,6 +55,26 @@ class TestCallbacks:
             },
         }
 
+    def test_inner_loop_callable_aggregation(self):
+        inner_loop = ciclo.callbacks.inner_loop(
+            "test",
+            dummy_inner_loop_fn,
+            aggregation=sum,
+        )
+
+        log_history, _ = inner_loop(None)
+
+        assert log_history == {
+            "stateful_metrics": {
+                "A_test": jnp.array(1.0, dtype=jnp.float32),
+                "B_test": jnp.array(1.0, dtype=jnp.float32),
+            },
+            "metrics": {
+                "C_test": jnp.array(1.0, dtype=jnp.float32),
+                "D_test": jnp.array(0.0, dtype=jnp.float32),
+            },
+        }
+
     def test_inner_loop_mean_aggregation(self):
         inner_loop = ciclo.callbacks.inner_loop(
             "test",

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,115 @@
+import jax.numpy as jnp
+
+import ciclo
+
+
+def dummy_inner_loop_fn(_):
+    log_history = [
+        {
+            "stateful_metrics": {
+                "A": jnp.array(1.0, dtype=jnp.float32),
+                "B": jnp.array(1.0, dtype=jnp.float32),
+            },
+            "metrics": {
+                "C": jnp.array(0.0, dtype=jnp.float32),
+                "D": jnp.array(0.0, dtype=jnp.float32),
+            },
+            "elapsed": {
+                "steps": 1,
+                "samples": 1,
+            },
+        },
+        {
+            "stateful_metrics": {
+                "A": jnp.array(0.0, dtype=jnp.float32),
+            },
+            "metrics": {
+                "C": jnp.array(1.0, dtype=jnp.float32),
+            },
+            "elapsed": {
+                "steps": 2,
+                "samples": 2,
+            },
+        },
+    ]
+    return None, log_history, None
+
+
+class TestCallbacks:
+    def test_inner_loop_default_aggregation(self):
+        inner_loop = ciclo.callbacks.inner_loop(
+            "test",
+            dummy_inner_loop_fn,
+        )
+
+        log_history, _ = inner_loop(None)
+
+        assert log_history == {
+            "stateful_metrics": {
+                "A_test": jnp.array(0.0, dtype=jnp.float32),
+                "B_test": jnp.array(1.0, dtype=jnp.float32),
+            },
+            "metrics": {
+                "C_test": jnp.array(1.0, dtype=jnp.float32),
+                "D_test": jnp.array(0.0, dtype=jnp.float32),
+            },
+        }
+
+    def test_inner_loop_mean_aggregation(self):
+        inner_loop = ciclo.callbacks.inner_loop(
+            "test",
+            dummy_inner_loop_fn,
+            aggregation="mean",
+        )
+
+        log_history, _ = inner_loop(None)
+
+        assert log_history == {
+            "stateful_metrics": {
+                "A_test": jnp.array(0.5, dtype=jnp.float32),
+                "B_test": jnp.array(1.0, dtype=jnp.float32),
+            },
+            "metrics": {
+                "C_test": jnp.array(0.5, dtype=jnp.float32),
+                "D_test": jnp.array(0.0, dtype=jnp.float32),
+            },
+        }
+
+    def test_inner_loop_aggregation_dict(self):
+        inner_loop = ciclo.callbacks.inner_loop(
+            "test",
+            dummy_inner_loop_fn,
+            aggregation={"stateful_metrics": "sum", "metrics": "min"},
+        )
+
+        log_history, _ = inner_loop(None)
+
+        assert log_history == {
+            "stateful_metrics": {
+                "A_test": jnp.array(1.0, dtype=jnp.float32),
+                "B_test": jnp.array(1.0, dtype=jnp.float32),
+            },
+            "metrics": {
+                "C_test": jnp.array(0.0, dtype=jnp.float32),
+                "D_test": jnp.array(0.0, dtype=jnp.float32),
+            },
+        }
+
+        inner_loop = ciclo.callbacks.inner_loop(
+            "test",
+            dummy_inner_loop_fn,
+            aggregation={"stateful_metrics": "first", "metrics": "last"},
+        )
+
+        log_history, _ = inner_loop(None)
+
+        assert log_history == {
+            "stateful_metrics": {
+                "A_test": jnp.array(1.0, dtype=jnp.float32),
+                "B_test": jnp.array(1.0, dtype=jnp.float32),
+            },
+            "metrics": {
+                "C_test": jnp.array(1.0, dtype=jnp.float32),
+                "D_test": jnp.array(0.0, dtype=jnp.float32),
+            },
+        }

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -93,7 +93,7 @@ class TestLoops:
             stop=1,
         )
 
-        assert history[0]['metrics']['a_test'] == 4
+        assert history[0]["metrics"]["a_test"] == 4
 
         state = {"a": 0}
 
@@ -109,4 +109,4 @@ class TestLoops:
             inner_loop_kwargs={"aggregation": "sum"},
         )
 
-        assert history[0]['metrics']['a_test'] == 10
+        assert history[0]["metrics"]["a_test"] == 10

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -72,3 +72,41 @@ class TestLoops:
 
         assert a_list == list(range(1, 4))
         assert b_list == list(range(-1, -4, -1))
+
+    def test_inner_loop_kwargs(self):
+        def increment(state, key):
+            state[key] += 1
+            logs = ciclo.logs()
+            logs.add_metric(key, state[key])
+            return logs, state
+
+        state = {"a": 0}
+
+        state, history, _ = ciclo.train_loop(
+            state,
+            ciclo.elapse(range(1)),
+            {
+                ciclo.on_test_step: lambda state: increment(state, "a"),
+            },
+            test_dataset=lambda: ciclo.elapse(range(4)),
+            epoch_duration=1,
+            stop=1,
+        )
+
+        assert history[0]['metrics']['a_test'] == 4
+
+        state = {"a": 0}
+
+        state, history, _ = ciclo.train_loop(
+            state,
+            ciclo.elapse(range(1)),
+            {
+                ciclo.on_test_step: lambda state: increment(state, "a"),
+            },
+            test_dataset=lambda: ciclo.elapse(range(4)),
+            epoch_duration=1,
+            stop=1,
+            inner_loop_kwargs={"aggregation": "sum"},
+        )
+
+        assert history[0]['metrics']['a_test'] == 10


### PR DESCRIPTION
Fixes #8.

This PR introduces an `aggregation` option for the `inner_loop` callback, which controls how the logs from the inner loop are aggregated. The default behavior of returning the last value for each entry in a collection is maintained. This is equivalent to manually setting `aggregation="last"`. 

`aggregation` supports a string value, one of `"last"`, `"first"`, `"min"`, `"max"`, `"mean`", and `"sum"` or a `Callable`. In this case, all values in all collections will be aggregated as specified. However, since some collections might require different aggregations (e.g., `"stateful_metrics"` and `"metrics"` likely want `"last"` and `"mean"`, respectively) it is also possible to specify a `dict` from collection to aggregation such as `{"stateful_metrics": "last", "metrics": "mean"}`. If a collection is not specified in this dictionary, then the `"last"` aggregation is used.

A `inner_loop_kwargs` argument has been added to `train_loop` in order to surface the aggregation options to a user of that API.

The PR also adds tests for both `aggregation` and `inner_loop_kwargs`.

Let me know what you think :) I also wasn't sure how best to document this functionality. 