### PR TITLE
Add initial patience & delta mode to early_stopping

### DIFF
--- a/ciclo/loops/loop.py
+++ b/ciclo/loops/loop.py
@@ -165,7 +165,7 @@ def loop(
         )
         for schedule, callbacks in tasks.items()
     ]
-    # prone empty tasks
+    # prune empty tasks
     schedule_callbacks = [x for x in schedule_callbacks if len(x[1]) > 0]
 
     try:

--- a/examples/flax/02_mnist_train_loop.py
+++ b/examples/flax/02_mnist_train_loop.py
@@ -117,7 +117,7 @@ state, history, _ = ciclo.train_loop(
         ciclo.checkpoint(
             f"logdir/{Path(__file__).stem}/{int(time())}",
             monitor="accuracy_test",
-            mode="max",
+            optimization_mode="max",
         ),
         ciclo.keras_bar(total=total_steps),
     ],

--- a/examples/flax/04_mnist_managed_api.py
+++ b/examples/flax/04_mnist_managed_api.py
@@ -105,12 +105,12 @@ state, history, *_ = ciclo.loop(
             ciclo.checkpoint(
                 f"logdir/{Path(__file__).stem}/{int(time())}",
                 monitor="accuracy_valid",
-                mode="max",
+                optimization_mode="max",
                 keep=3,
             ),
             ciclo.early_stopping(
                 monitor="accuracy_valid",
-                mode="max",
+                optimization_mode="max",
                 patience=eval_steps * 2,
             ),
             reset_metrics,

--- a/examples/flax/05_mnist_flax_state.py
+++ b/examples/flax/05_mnist_flax_state.py
@@ -55,7 +55,7 @@ state, history, _ = ciclo.train_loop(
         ciclo.checkpoint(
             f"logdir/{Path(__file__).stem}/{int(time())}",
             monitor="accuracy_test",
-            mode="max",
+            optimization_mode="max",
         ),
     ],
     test_dataset=lambda: ds_test.as_numpy_iterator(),

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -35,7 +35,7 @@ def dummy_inner_loop_fn(_):
     return None, log_history, None
 
 
-class TestCallbacks:
+class TestInnerLoop:
     def test_inner_loop_default_aggregation(self):
         inner_loop = ciclo.callbacks.inner_loop(
             "test",
@@ -133,3 +133,186 @@ class TestCallbacks:
                 "D_test": jnp.array(0.0, dtype=jnp.float32),
             },
         }
+
+
+class TestEarlyStopping:
+    def test_patience(self):
+        dataset = jnp.minimum(jnp.arange(10), 5)
+
+        def train_step(state, batch):
+            logs = ciclo.logs()
+            logs.add_metric("x", batch)
+            return logs, state
+
+        _, history, _ = ciclo.loop(
+            None,
+            dataset,
+            {
+                ciclo.every(1): [
+                    train_step,
+                    ciclo.early_stopping("x", optimization_mode="max", patience=1),
+                ],
+            },
+        )
+
+        assert len(history) == 7
+
+        _, history, _ = ciclo.loop(
+            None,
+            dataset,
+            {
+                ciclo.every(1): [
+                    train_step,
+                    ciclo.early_stopping("x", optimization_mode="max", patience=3),
+                ],
+            },
+        )
+
+        assert len(history) == 9
+
+    def test_initial_patience(self):
+        dataset = jnp.maximum(jnp.minimum(jnp.arange(10), 5), 2)
+
+        def train_step(state, batch):
+            logs = ciclo.logs()
+            logs.add_metric("x", batch)
+            return logs, state
+
+        _, history, _ = ciclo.loop(
+            None,
+            dataset,
+            {
+                ciclo.every(1): [
+                    train_step,
+                    ciclo.early_stopping(
+                        "x", optimization_mode="max", patience=1, initial_patience=1
+                    ),
+                ],
+            },
+        )
+
+        assert len(history) == 2
+
+        _, history, _ = ciclo.loop(
+            None,
+            dataset,
+            {
+                ciclo.every(1): [
+                    train_step,
+                    ciclo.early_stopping(
+                        "x", optimization_mode="max", patience=1, initial_patience=3
+                    ),
+                ],
+            },
+        )
+
+        assert len(history) == 7
+
+    def test_min_optimization_mode(self):
+        dataset = jnp.maximum(jnp.minimum(jnp.arange(9, 0, -1), 6), 3)
+
+        def train_step(state, batch):
+            logs = ciclo.logs()
+            logs.add_metric("x", batch)
+            return logs, state
+
+        _, history, _ = ciclo.loop(
+            None,
+            dataset,
+            {
+                ciclo.every(1): [
+                    train_step,
+                    ciclo.early_stopping(
+                        "x", optimization_mode="min", patience=1, initial_patience=4
+                    ),
+                ],
+            },
+        )
+
+        assert len(history) == 8
+
+    def test_min_delta(self):
+        dataset = jnp.arange(0, 1, 0.1)
+
+        def train_step(state, batch):
+            logs = ciclo.logs()
+            logs.add_metric("x", batch)
+            return logs, state
+
+        _, history, _ = ciclo.loop(
+            None,
+            dataset,
+            {
+                ciclo.every(1): [
+                    train_step,
+                    ciclo.early_stopping(
+                        "x",
+                        optimization_mode="max",
+                        patience=1,
+                        min_delta=0.01,
+                    ),
+                ],
+            },
+        )
+
+        assert len(history) == 10
+
+        _, history, _ = ciclo.loop(
+            None,
+            dataset,
+            {
+                ciclo.every(1): [
+                    train_step,
+                    ciclo.early_stopping(
+                        "x", optimization_mode="max", patience=1, min_delta=0.1
+                    ),
+                ],
+            },
+        )
+
+        assert len(history) == 2
+
+        _, history, _ = ciclo.loop(
+            None,
+            dataset,
+            {
+                ciclo.every(1): [
+                    train_step,
+                    ciclo.early_stopping(
+                        "x",
+                        optimization_mode="max",
+                        patience=3,
+                        min_delta=0.05,
+                    ),
+                ],
+            },
+        )
+
+        assert len(history) == 10
+
+    def test_min_relative_delta(self):
+        dataset = jnp.arange(0, 1, 0.1)
+
+        def train_step(state, batch):
+            logs = ciclo.logs()
+            logs.add_metric("x", batch)
+            return logs, state
+
+        _, history, _ = ciclo.loop(
+            None,
+            dataset,
+            {
+                ciclo.every(1): [
+                    train_step,
+                    ciclo.early_stopping(
+                        "x",
+                        optimization_mode="max",
+                        patience=1,
+                        min_delta=0.5,
+                        delta_mode="relative",
+                    ),
+                ],
+            },
+        )
+
+        assert len(history) == 4

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -177,11 +177,11 @@ class TestIntegration:
                         ciclo.checkpoint(
                             f"{logdir}/model",
                             monitor="accuracy_valid",
-                            mode="max",
+                            optimization_mode="max",
                         ),
                         ciclo.early_stopping(
                             monitor="accuracy_valid",
-                            mode="max",
+                            optimization_mode="max",
                             patience=100,
                         ),
                     ],
@@ -230,7 +230,7 @@ class TestIntegration:
                 ciclo.checkpoint(
                     f"logdir/{Path(__file__).stem}/{int(time())}",
                     monitor="accuracy_test",
-                    mode="max",
+                    optimization_mode="max",
                 ),
             ],
             test_dataset=lambda: get_tuple_dataset(batch_size),


### PR DESCRIPTION
(Mostly) addresses #11.  

The main changes are:
 * Fix `min_delta` being ignored by the `early_stopping` callback.
 * Add a `delta_mode` option to early stopping that allows `min_delta` to either be interpreted as a `"absolute"` or `"relative"` difference. 
 * Add an `initial_patience` option, which is the same as `patience` but only considers the first `n` steps. This is useful when the initial stages of training are very noisy, etc. It is similar to `start_from_epoch` from Keras.
* Renamed existing "mode" to "optimization_mode" for clarity. (Also in the `checkpoint` callback, for consistency).
* Added tests.

This doesn't address the problem that the best weights are only returned if the patience has run out. After looking more closely at the code, I think that fixing it requires a more considerable refactoring of the code, so I'll make another issue to discuss. In short, I would like to upgrade the callback functionality such that each callback can have multiple callback functions. E.g., the `early_stopping` callback could have a generic `__loop_callback__` that is called on the schedule specified by the user, *and* a `on_epoch_end` that is called at the end of training. This seems to be how the Keras callbacks work, and as far as I understand, it isn't possible with the current setup. But more on that later, let me know what you think of these changes! 