### PR TITLE
Remove `orbax` dependency as it is not used anywhere in library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -888,7 +888,6 @@ jax = ">=0.4.2"
 msgpack = "*"
 numpy = ">=1.12"
 optax = "*"
-orbax = "*"
 PyYAML = ">=5.4.1"
 rich = ">=11.1"
 tensorstore = "*"
@@ -2142,33 +2141,6 @@ jax = ">=0.1.55"
 jaxlib = ">=0.1.37"
 numpy = ">=1.18.0"
 typing-extensions = ">=3.10.0"
-
-[[package]]
-name = "orbax"
-version = "0.1.3"
-description = "Orbax"
-category = "main"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "orbax-0.1.3-py3-none-any.whl", hash = "sha256:a5268b372f28dd085ef1c400f0eb7514fd235c719989b5caa145f1ae5773811f"},
-    {file = "orbax-0.1.3.tar.gz", hash = "sha256:e65171df1734da28478d8a2f2da837416e7c7a026a6280dc93264324ea40df5a"},
-]
-
-[package.dependencies]
-absl-py = "*"
-cached_property = "*"
-etils = "*"
-flax = "*"
-importlib_resources = "*"
-jax = ">=0.4.1"
-jaxlib = "*"
-numpy = "*"
-pyyaml = "*"
-tensorstore = ">=0.1.20"
-
-[package.extras]
-dev = ["pytest", "pytest-xdist"]
 
 [[package]]
 name = "packaging"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ einop = "*"
 numpy = "*" 
 # jax-metrics = {path = "../jax_metrics"}
 jax-metrics = "^0.2.1"
-orbax = "<0.1.4"
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=7.1.3"


### PR DESCRIPTION
I did not find any usages for `orbax` in the `ciclo` library. Furthermore, the strict requirement for an old `orbax` version started to cause issues (as for example the old `orbax` version was still using deprecated jax code).